### PR TITLE
docker: Add docker-compose.yml for local dev

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,45 @@
+services:
+  db:
+    image: postgres:16-alpine
+    environment:
+      POSTGRES_DB: agentlogs
+      POSTGRES_USER: agentlogs
+      POSTGRES_PASSWORD: agentlogs
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+
+  minio:
+    image: minio/minio
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    volumes:
+      - miniodata:/data
+
+  web:
+    build: .
+    ports:
+      - "3000:3000"
+    depends_on:
+      - db
+      - minio
+    environment:
+      DATABASE_URL: postgres://agentlogs:agentlogs@db:5432/agentlogs
+      S3_ENDPOINT: http://minio:9000
+      S3_BUCKET: agentlogs
+      S3_REGION: us-east-1
+      S3_ACCESS_KEY: minioadmin
+      S3_SECRET_KEY: minioadmin
+      WEB_URL: http://localhost:3000
+      BETTER_AUTH_SECRET: dev-secret-change-me
+      # Set GITHUB_CLIENT_ID and GITHUB_CLIENT_SECRET for OAuth
+
+volumes:
+  pgdata:
+  miniodata:


### PR DESCRIPTION
## Summary
- Add `docker-compose.yml` with Postgres, MinIO (S3-compatible), and the app
- MinIO console available at `:9001` for inspecting stored blobs
- Pre-configured with all S3 env vars pointing to the MinIO service

## Test plan
- [ ] `docker compose up` — app starts, migrations run, MinIO available
- [ ] Upload a transcript → blob stored in MinIO (check via MinIO console at :9001)
- [ ] View transcript → blob retrieved from MinIO

🤖 Generated with [Claude Code](https://claude.com/claude-code)