### PR TITLE
web: Fix Date serialization in Drizzle SQL template literals

### DIFF
--- a/packages/web/src/db/queries.ts
+++ b/packages/web/src/db/queries.ts
@@ -705,7 +705,7 @@ export async function getDailyActivityCounts(db: DrizzleDB, viewerId: string, da
       count: sql<number>`CAST(COUNT(*) AS INTEGER)`.as("count"),
     })
     .from(transcripts)
-    .where(and(buildVisibilityCondition(viewerId), sql`${transcripts.createdAt} >= ${startDate}`))
+    .where(and(buildVisibilityCondition(viewerId), sql`${transcripts.createdAt} >= ${startDate.toISOString()}`))
     .groupBy(sql`${transcripts.createdAt}::date`)
     .orderBy(sql`${transcripts.createdAt}::date`);
 
@@ -736,7 +736,7 @@ function buildTeamVisibleCondition(teamId: string) {
  * Build condition for transcripts visible to a team with date filter.
  */
 function buildTeamVisibleConditionWithDate(teamId: string, startDate: Date) {
-  return and(buildTeamVisibleCondition(teamId), sql`${transcripts.createdAt} >= ${startDate}`);
+  return and(buildTeamVisibleCondition(teamId), sql`${transcripts.createdAt} >= ${startDate.toISOString()}`);
 }
 
 /**
@@ -849,7 +849,7 @@ export async function getTeamMemberStats(db: DrizzleDB, teamId: string, days: nu
           and(eq(transcripts.visibility, "team"), eq(transcripts.sharedWithTeamId, teamId)),
           eq(transcripts.visibility, "public"),
         ),
-        sql`${transcripts.createdAt} >= ${startDate}`,
+        sql`${transcripts.createdAt} >= ${startDate.toISOString()}`,
       ),
     )
     .where(eq(teamMembers.teamId, teamId))
@@ -872,7 +872,7 @@ export async function getTeamMemberStats(db: DrizzleDB, teamId: string, days: nu
           and(eq(transcripts.visibility, "team"), eq(transcripts.sharedWithTeamId, teamId)),
           eq(transcripts.visibility, "public"),
         ),
-        sql`${transcripts.createdAt} >= ${startDate}`,
+        sql`${transcripts.createdAt} >= ${startDate.toISOString()}`,
         sql`${transcripts.model} IS NOT NULL`,
       ),
     )
@@ -895,7 +895,7 @@ export async function getTeamMemberStats(db: DrizzleDB, teamId: string, days: nu
           and(eq(transcripts.visibility, "team"), eq(transcripts.sharedWithTeamId, teamId)),
           eq(transcripts.visibility, "public"),
         ),
-        sql`${transcripts.createdAt} >= ${startDate}`,
+        sql`${transcripts.createdAt} >= ${startDate.toISOString()}`,
       ),
     )
     .groupBy(transcripts.userId, transcripts.source)


### PR DESCRIPTION
## Summary
- Fix JS `Date` objects being serialized via `.toString()` in Drizzle `sql` template literals, producing a format PostgreSQL can't parse
- Use `.toISOString()` in all 5 occurrences in `queries.ts` to produce ISO 8601 format
- Fixes `/app` page failing to load and team dashboard query errors

## Test plan
- [x] `bun run check` passes (format, lint, type check)
- [x] Pre-commit hook tests pass
- [ ] Navigate to `/app` — page loads without query errors
- [ ] Check team dashboard pages load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)